### PR TITLE
Make RabbitMqApi's HttpClient an instance method

### DIFF
--- a/RabbitMqHttpApiClient/API/RabbitMqApi.cs
+++ b/RabbitMqHttpApiClient/API/RabbitMqApi.cs
@@ -20,6 +20,16 @@ namespace RabbitMqHttpApiClient.API
                 new AuthenticationHeaderValue("Basic", basicAuthHeader);
         }
 
+        public RabbitMqApi(HttpClient httpClient)
+        {
+            if (httpClient == null)
+            {
+                throw new ArgumentNullException(nameof(httpClient));
+            }
+
+            Http = httpClient;
+        }
+
         private async Task<T> DoGetCall<T>(string path)
         {
             return await DoCall<T>(path, HttpMethod.Get);

--- a/RabbitMqHttpApiClient/API/RabbitMqApi.cs
+++ b/RabbitMqHttpApiClient/API/RabbitMqApi.cs
@@ -9,17 +9,12 @@ namespace RabbitMqHttpApiClient.API
 {
     public partial class RabbitMqApi
     {
-        private static readonly HttpClient Http;
-
-        static RabbitMqApi()
-        {
-            Http = new HttpClient { Timeout = TimeSpan.FromMinutes(2) };
-        }
+        private readonly HttpClient Http;
 
         public RabbitMqApi(string rabbitMqUrl, string username, string password)
         {
             var basicAuthHeader = Convert.ToBase64String(Encoding.ASCII.GetBytes($"{username}:{password}"));
-
+            Http = new HttpClient { Timeout = TimeSpan.FromMinutes(2) };
             Http.BaseAddress = new Uri(rabbitMqUrl);
             Http.DefaultRequestHeaders.Authorization =
                 new AuthenticationHeaderValue("Basic", basicAuthHeader);


### PR DESCRIPTION
Hi @kuanysh-nabiyev,

firstly, thanks for sharing your work with us. This saved a lot of work on my side. 🥇 

I had to change the HttpClient from static to a normal instance method to support my use case. I think this change will not impact you. With the current implementation using the static HttpClient the RabbitMqApi can only be instantiated once. The reason is that the properties of the HttpClient cannot be changed after a request was made. The constructor changes the base url and adds an header. Therefore an InvalidOperationException is thrown.

Have a look at that sample:

```C#
 static void Main(string[] args)
        {
            var rabbitMqApi = new RabbitMqApi("http://localhost:15672", "guest", "guest");
            rabbitMqApi.GetOverview();

            // this generates an exception, as the static httpClient was already once used and its properties must not be changed afterwards
            //System.InvalidOperationException: 'This instance has already started one or more requests. Properties can only be modified before sending the first request.'
            var rabbitMqApi2 = new RabbitMqApi("http://localhost:15672", "guest", "guest");
        }
```

Additionally, I have added a second constructor accepting a pre configured HttpClient. This would make it way easier for me to use the api.