### PR TITLE
Most properties of the type int are converted to long.

### DIFF
--- a/RabbitMqHttpApiClient/API/RabbitMqApi.Queue.cs
+++ b/RabbitMqHttpApiClient/API/RabbitMqApi.Queue.cs
@@ -44,7 +44,7 @@ namespace RabbitMqHttpApiClient.API
         /// <param name="encoding">must be either "auto" (in which case the payload will be returned as a string if it is valid UTF-8, and base64 encoded otherwise), or "base64" (in which case the payload will always be base64 encoded).</param>
         /// <returns></returns>
         public async Task<IEnumerable<QueueMessage>> GetQueueMessages(string virtualHost, string queueName, 
-            int count = Int32.MaxValue, bool requeue = true, PayloadEncoding encoding = PayloadEncoding.Auto)
+            long count = Int64.MaxValue, bool requeue = true, PayloadEncoding encoding = PayloadEncoding.Auto)
         {
             var request = new GetQueueMessagesRequest
             {

--- a/RabbitMqHttpApiClient/Models/ChannelModel/Channel.cs
+++ b/RabbitMqHttpApiClient/Models/ChannelModel/Channel.cs
@@ -26,31 +26,31 @@ namespace RabbitMqHttpApiClient.Models.ChannelModel
         public GarbageCollection GarbageCollection { get; set; }
 
         [JsonProperty("reductions")]
-        public int Reductions { get; set; }
+        public long Reductions { get; set; }
 
         [JsonProperty("state")]
         public string State { get; set; }
 
         [JsonProperty("global_prefetch_count")]
-        public int GlobalPrefetchCount { get; set; }
+        public long GlobalPrefetchCount { get; set; }
 
         [JsonProperty("prefetch_count")]
-        public int PrefetchCount { get; set; }
+        public long PrefetchCount { get; set; }
 
         [JsonProperty("acks_uncommitted")]
-        public int AcksUncommitted { get; set; }
+        public long AcksUncommitted { get; set; }
 
         [JsonProperty("messages_uncommitted")]
-        public int MessagesUncommitted { get; set; }
+        public long MessagesUncommitted { get; set; }
 
         [JsonProperty("messages_unconfirmed")]
-        public int MessagesUnconfirmed { get; set; }
+        public long MessagesUnconfirmed { get; set; }
 
         [JsonProperty("messages_unacknowledged")]
-        public int MessagesUnacknowledged { get; set; }
+        public long MessagesUnacknowledged { get; set; }
 
         [JsonProperty("consumer_count")]
-        public int ConsumerCount { get; set; }
+        public long ConsumerCount { get; set; }
 
         [JsonProperty("confirm")]
         public bool Confirm { get; set; }

--- a/RabbitMqHttpApiClient/Models/Common/MessageStats.cs
+++ b/RabbitMqHttpApiClient/Models/Common/MessageStats.cs
@@ -6,40 +6,40 @@ namespace RabbitMqHttpApiClient.Models.Common
         : IPublishInfo, IAck, IDeliverGet, IConfirm, IReturnUnroutable, 
           IRedeliver, IDeliver, IDeliverNoAck, IGet, IGetNoAck
     {
-        public int Publish { get; set; }
+        public long Publish { get; set; }
         public RateDetails PublishDetails { get; set; }
 
-        public int PublishIn { get; set; }
+        public long PublishIn { get; set; }
         public RateDetails PublishInDetails { get; set; }
 
-        public int PublishOut { get; set; }
+        public long PublishOut { get; set; }
         public RateDetails PublishOutDetails { get; set; }
 
-        public int Ack { get; set; }
+        public long Ack { get; set; }
         public RateDetails AckDetails { get; set; }
 
-        public int DeliverGet { get; set; }
+        public long DeliverGet { get; set; }
         public RateDetails DeliverGetDetails { get; set; }
 
-        public int Confirm { get; set; }
+        public long Confirm { get; set; }
         public RateDetails ConfirmDetails { get; set; }
 
-        public int ReturnUnroutable { get; set; }
+        public long ReturnUnroutable { get; set; }
         public RateDetails ReturnUnroutableDetails { get; set; }
 
-        public int Redeliver { get; set; }
+        public long Redeliver { get; set; }
         public RateDetails RedeliverDetails { get; set; }
 
-        public int Deliver { get; set; }
+        public long Deliver { get; set; }
         public RateDetails DeliverDetails { get; set; }
 
-        public int DeliverNoAck { get; set; }
+        public long DeliverNoAck { get; set; }
         public RateDetails DeliverNoAckDetails { get; set; }
 
-        public int Get { get; set; }
+        public long Get { get; set; }
         public RateDetails GetDetails { get; set; }
 
-        public int GetNoAck { get; set; }
+        public long GetNoAck { get; set; }
         public RateDetails GetNoAckDetails { get; set; }
     }
 }

--- a/RabbitMqHttpApiClient/Models/Common/MessageStatsModel/IAck.cs
+++ b/RabbitMqHttpApiClient/Models/Common/MessageStatsModel/IAck.cs
@@ -5,7 +5,7 @@ namespace RabbitMqHttpApiClient.Models.Common.MessageStatsModel
     public interface IAck
     {
         [JsonProperty("ack")]
-        int Ack { get; set; }
+        long Ack { get; set; }
 
         [JsonProperty("ack_details")]
         RateDetails AckDetails { get; set; }

--- a/RabbitMqHttpApiClient/Models/Common/MessageStatsModel/IConfirm.cs
+++ b/RabbitMqHttpApiClient/Models/Common/MessageStatsModel/IConfirm.cs
@@ -5,7 +5,7 @@ namespace RabbitMqHttpApiClient.Models.Common.MessageStatsModel
     public interface IConfirm
     {
         [JsonProperty("confirm")]
-        int Confirm { get; set; }
+        long Confirm { get; set; }
 
         [JsonProperty("confirm_details")]
         RateDetails ConfirmDetails { get; set; }

--- a/RabbitMqHttpApiClient/Models/Common/MessageStatsModel/IDeliver.cs
+++ b/RabbitMqHttpApiClient/Models/Common/MessageStatsModel/IDeliver.cs
@@ -5,7 +5,7 @@ namespace RabbitMqHttpApiClient.Models.Common.MessageStatsModel
     public interface IDeliver
     {
         [JsonProperty("deliver")]
-        int Deliver { get; set; }
+        long Deliver { get; set; }
 
         [JsonProperty("deliver_details")]
         RateDetails DeliverDetails { get; set; }

--- a/RabbitMqHttpApiClient/Models/Common/MessageStatsModel/IDeliverGet.cs
+++ b/RabbitMqHttpApiClient/Models/Common/MessageStatsModel/IDeliverGet.cs
@@ -5,7 +5,7 @@ namespace RabbitMqHttpApiClient.Models.Common.MessageStatsModel
     public interface IDeliverGet
     {
         [JsonProperty("deliver_get")]
-        int DeliverGet { get; set; }
+        long DeliverGet { get; set; }
 
         [JsonProperty("deliver_get_details")]
         RateDetails DeliverGetDetails { get; set; }

--- a/RabbitMqHttpApiClient/Models/Common/MessageStatsModel/IDeliverNoAck.cs
+++ b/RabbitMqHttpApiClient/Models/Common/MessageStatsModel/IDeliverNoAck.cs
@@ -5,7 +5,7 @@ namespace RabbitMqHttpApiClient.Models.Common.MessageStatsModel
     public interface IDeliverNoAck
     {
         [JsonProperty("deliver_no_ack")]
-        int DeliverNoAck { get; set; }
+        long DeliverNoAck { get; set; }
 
         [JsonProperty("deliver_no_ack_details")]
         RateDetails DeliverNoAckDetails { get; set; }

--- a/RabbitMqHttpApiClient/Models/Common/MessageStatsModel/IDiskInfo.cs
+++ b/RabbitMqHttpApiClient/Models/Common/MessageStatsModel/IDiskInfo.cs
@@ -5,13 +5,13 @@ namespace RabbitMqHttpApiClient.Models.Common.MessageStatsModel
     public interface IDiskInfo
     {
         [JsonProperty("disk_reads")]
-        int DiskReads { get; set; }
+        long DiskReads { get; set; }
 
         [JsonProperty("disk_reads_details")]
         RateDetails DiskReadsDetails { get; set; }
 
         [JsonProperty("disk_writes")]
-        int DiskWrites { get; set; }
+        long DiskWrites { get; set; }
 
         [JsonProperty("disk_writes_details")]
         RateDetails DiskWritesDetails { get; set; }

--- a/RabbitMqHttpApiClient/Models/Common/MessageStatsModel/IGet.cs
+++ b/RabbitMqHttpApiClient/Models/Common/MessageStatsModel/IGet.cs
@@ -5,7 +5,7 @@ namespace RabbitMqHttpApiClient.Models.Common.MessageStatsModel
     public interface IGet
     {
         [JsonProperty("get")]
-        int Get { get; set; }
+        long Get { get; set; }
 
         [JsonProperty("get_details")]
         RateDetails GetDetails { get; set; }

--- a/RabbitMqHttpApiClient/Models/Common/MessageStatsModel/IGetNoAck.cs
+++ b/RabbitMqHttpApiClient/Models/Common/MessageStatsModel/IGetNoAck.cs
@@ -5,7 +5,7 @@ namespace RabbitMqHttpApiClient.Models.Common.MessageStatsModel
     public interface IGetNoAck
     {
         [JsonProperty("get_no_ack")]
-        int GetNoAck { get; set; }
+        long GetNoAck { get; set; }
 
         [JsonProperty("get_no_ack_details")]
         RateDetails GetNoAckDetails { get; set; }

--- a/RabbitMqHttpApiClient/Models/Common/MessageStatsModel/IPublishInfo.cs
+++ b/RabbitMqHttpApiClient/Models/Common/MessageStatsModel/IPublishInfo.cs
@@ -5,19 +5,19 @@ namespace RabbitMqHttpApiClient.Models.Common.MessageStatsModel
     public interface IPublishInfo
     {
         [JsonProperty("publish")]
-        int Publish { get; set; }
+        long Publish { get; set; }
 
         [JsonProperty("publish_details")]
         RateDetails PublishDetails { get; set; }
 
         [JsonProperty("publish_in")]
-        int PublishIn { get; set; }
+        long PublishIn { get; set; }
 
         [JsonProperty("publish_in_details")]
         RateDetails PublishInDetails { get; set; }
 
         [JsonProperty("publish_out")]
-        int PublishOut { get; set; }
+        long PublishOut { get; set; }
 
         [JsonProperty("publish_out_details")]
         RateDetails PublishOutDetails { get; set; }

--- a/RabbitMqHttpApiClient/Models/Common/MessageStatsModel/IRedeliver.cs
+++ b/RabbitMqHttpApiClient/Models/Common/MessageStatsModel/IRedeliver.cs
@@ -5,7 +5,7 @@ namespace RabbitMqHttpApiClient.Models.Common.MessageStatsModel
     public interface IRedeliver
     {
         [JsonProperty("redeliver")]
-        int Redeliver { get; set; }
+        long Redeliver { get; set; }
 
         [JsonProperty("redeliver_details")]
         RateDetails RedeliverDetails { get; set; }

--- a/RabbitMqHttpApiClient/Models/Common/MessageStatsModel/IReturnUnroutable.cs
+++ b/RabbitMqHttpApiClient/Models/Common/MessageStatsModel/IReturnUnroutable.cs
@@ -5,7 +5,7 @@ namespace RabbitMqHttpApiClient.Models.Common.MessageStatsModel
     public interface IReturnUnroutable
     {
         [JsonProperty("return_unroutable")]
-        int ReturnUnroutable { get; set; }
+        long ReturnUnroutable { get; set; }
 
         [JsonProperty("return_unroutable_details")]
         RateDetails ReturnUnroutableDetails { get; set; }

--- a/RabbitMqHttpApiClient/Models/ConnectionModel/Connection.cs
+++ b/RabbitMqHttpApiClient/Models/ConnectionModel/Connection.cs
@@ -81,7 +81,7 @@ namespace RabbitMqHttpApiClient.Models.ConnectionModel
         public GarbageCollection GarbageCollection { get; set; }
 
         [JsonProperty("reductions")]
-        public int Reductions { get; set; }
+        public long Reductions { get; set; }
 
         [JsonProperty("channels")]
         public int Channels { get; set; }
@@ -90,25 +90,25 @@ namespace RabbitMqHttpApiClient.Models.ConnectionModel
         public string State { get; set; }
 
         [JsonProperty("send_pend")]
-        public int SendPend { get; set; }
+        public long SendPend { get; set; }
 
         [JsonProperty("send_cnt")]
-        public int SendCnt { get; set; }
+        public long SendCnt { get; set; }
 
         [JsonProperty("recv_cnt")]
-        public int RecvCnt { get; set; }
+        public long RecvCnt { get; set; }
 
         [JsonProperty("recv_oct_details")]
         public RateDetails RecvOctDetails { get; set; }
 
         [JsonProperty("recv_oct")]
-        public int RecvOct { get; set; }
+        public long RecvOct { get; set; }
 
         [JsonProperty("send_oct_details")]
         public RateDetails SendOctDetails { get; set; }
 
         [JsonProperty("send_oct")]
-        public int SendOct { get; set; }
+        public long SendOct { get; set; }
 
         [JsonProperty("reductions_details")]
         public RateDetails ReductionsDetails { get; set; }

--- a/RabbitMqHttpApiClient/Models/ConsumerModel/Consumer.cs
+++ b/RabbitMqHttpApiClient/Models/ConsumerModel/Consumer.cs
@@ -9,7 +9,7 @@ namespace RabbitMqHttpApiClient.Models.ConsumerModel
         public Arguments Arguments { get; set; }
 
         [JsonProperty("prefetch_count")]
-        public int PrefetchCount { get; set; }
+        public long PrefetchCount { get; set; }
 
         [JsonProperty("ack_required")]
         public bool AckRequired { get; set; }

--- a/RabbitMqHttpApiClient/Models/ExchangeModel/MessageStats.cs
+++ b/RabbitMqHttpApiClient/Models/ExchangeModel/MessageStats.cs
@@ -6,28 +6,28 @@ namespace RabbitMqHttpApiClient.Models.ExchangeModel
     public class MessageStats 
         : IPublishInfo, IAck, IDeliverGet, IConfirm, IReturnUnroutable, IRedeliver
     {
-        public int Publish { get; set; }
+        public long Publish { get; set; }
         public RateDetails PublishDetails { get; set; }
 
-        public int PublishIn { get; set; }
+        public long PublishIn { get; set; }
         public RateDetails PublishInDetails { get; set; }
 
-        public int PublishOut { get; set; }
+        public long PublishOut { get; set; }
         public RateDetails PublishOutDetails { get; set; }
 
-        public int Ack { get; set; }
+        public long Ack { get; set; }
         public RateDetails AckDetails { get; set; }
 
-        public int DeliverGet { get; set; }
+        public long DeliverGet { get; set; }
         public RateDetails DeliverGetDetails { get; set; }
 
-        public int Confirm { get; set; }
+        public long Confirm { get; set; }
         public RateDetails ConfirmDetails { get; set; }
 
-        public int ReturnUnroutable { get; set; }
+        public long ReturnUnroutable { get; set; }
         public RateDetails ReturnUnroutableDetails { get; set; }
 
-        public int Redeliver { get; set; }
+        public long Redeliver { get; set; }
         public RateDetails RedeliverDetails { get; set; }
     }
 }

--- a/RabbitMqHttpApiClient/Models/NodeModel/Node.cs
+++ b/RabbitMqHttpApiClient/Models/NodeModel/Node.cs
@@ -45,13 +45,13 @@ namespace RabbitMqHttpApiClient.Models.NodeModel
         public RateDetails DiskFreeDetails { get; set; }
 
         [JsonProperty("io_read_count")]
-        public int IoReadCount { get; set; }
+        public long IoReadCount { get; set; }
 
         [JsonProperty("io_read_count_details")]
         public RateDetails IoReadCountDetails { get; set; }
 
         [JsonProperty("io_read_bytes")]
-        public int IoReadBytes { get; set; }
+        public long IoReadBytes { get; set; }
 
         [JsonProperty("io_read_bytes_details")]
         public RateDetails IoReadBytesDetails { get; set; }
@@ -63,13 +63,13 @@ namespace RabbitMqHttpApiClient.Models.NodeModel
         public RateDetails IoReadAvgTimeDetails { get; set; }
 
         [JsonProperty("io_write_count")]
-        public int IoWriteCount { get; set; }
+        public long IoWriteCount { get; set; }
 
         [JsonProperty("io_write_count_details")]
         public RateDetails IoWriteCountDetails { get; set; }
 
         [JsonProperty("io_write_bytes")]
-        public int IoWriteBytes { get; set; }
+        public long IoWriteBytes { get; set; }
 
         [JsonProperty("io_write_bytes_details")]
         public RateDetails IoWriteBytesDetails { get; set; }
@@ -81,7 +81,7 @@ namespace RabbitMqHttpApiClient.Models.NodeModel
         public RateDetails IoWriteAvgTimeDetails { get; set; }
 
         [JsonProperty("io_sync_count")]
-        public int IoSyncCount { get; set; }
+        public long IoSyncCount { get; set; }
 
         [JsonProperty("io_sync_count_details")]
         public RateDetails IoSyncCountDetails { get; set; }
@@ -93,7 +93,7 @@ namespace RabbitMqHttpApiClient.Models.NodeModel
         public RateDetails IoSyncAvgTimeDetails { get; set; }
 
         [JsonProperty("io_seek_count")]
-        public int IoSeekCount { get; set; }
+        public long IoSeekCount { get; set; }
 
         [JsonProperty("io_seek_count_details")]
         public RateDetails IoSeekCountDetails { get; set; }
@@ -105,49 +105,49 @@ namespace RabbitMqHttpApiClient.Models.NodeModel
         public RateDetails IoSeekAvgTimeDetails { get; set; }
 
         [JsonProperty("io_reopen_count")]
-        public int IoReopenCount { get; set; }
+        public long IoReopenCount { get; set; }
 
         [JsonProperty("io_reopen_count_details")]
         public RateDetails IoReopenCountDetails { get; set; }
 
         [JsonProperty("mnesia_ram_tx_count")]
-        public int MnesiaRamTxCount { get; set; }
+        public long MnesiaRamTxCount { get; set; }
 
         [JsonProperty("mnesia_ram_tx_count_details")]
         public RateDetails MnesiaRamTxCountDetails { get; set; }
 
         [JsonProperty("mnesia_disk_tx_count")]
-        public int MnesiaDiskTxCount { get; set; }
+        public long MnesiaDiskTxCount { get; set; }
 
         [JsonProperty("mnesia_disk_tx_count_details")]
         public RateDetails MnesiaDiskTxCountDetails { get; set; }
 
         [JsonProperty("msg_store_read_count")]
-        public int MsgStoreReadCount { get; set; }
+        public long MsgStoreReadCount { get; set; }
 
         [JsonProperty("msg_store_read_count_details")]
         public RateDetails MsgStoreReadCountDetails { get; set; }
 
         [JsonProperty("msg_store_write_count")]
-        public int MsgStoreWriteCount { get; set; }
+        public long MsgStoreWriteCount { get; set; }
 
         [JsonProperty("msg_store_write_count_details")]
         public RateDetails MsgStoreWriteCountDetails { get; set; }
 
         [JsonProperty("queue_index_journal_write_count")]
-        public int QueueIndexJournalWriteCount { get; set; }
+        public long QueueIndexJournalWriteCount { get; set; }
 
         [JsonProperty("queue_index_journal_write_count_details")]
         public RateDetails QueueIndexJournalWriteCountDetails { get; set; }
 
         [JsonProperty("queue_index_write_count")]
-        public int QueueIndexWriteCount { get; set; }
+        public long QueueIndexWriteCount { get; set; }
 
         [JsonProperty("queue_index_write_count_details")]
         public RateDetails QueueIndexWriteCountDetails { get; set; }
 
         [JsonProperty("queue_index_read_count")]
-        public int QueueIndexReadCount { get; set; }
+        public long QueueIndexReadCount { get; set; }
 
         [JsonProperty("queue_index_read_count_details")]
         public RateDetails QueueIndexReadCountDetails { get; set; }
@@ -165,13 +165,13 @@ namespace RabbitMqHttpApiClient.Models.NodeModel
         public RateDetails GcBytesReclaimedDetails { get; set; }
 
         [JsonProperty("context_switches")]
-        public int ContextSwitches { get; set; }
+        public long ContextSwitches { get; set; }
 
         [JsonProperty("context_switches_details")]
         public RateDetails ContextSwitchesDetails { get; set; }
 
         [JsonProperty("io_file_handle_open_attempt_count")]
-        public int IoFileHandleOpenAttemptCount { get; set; }
+        public long IoFileHandleOpenAttemptCount { get; set; }
 
         [JsonProperty("io_file_handle_open_attempt_count_details")]
         public RateDetails IoFileHandleOpenAttemptCountDetails { get; set; }
@@ -201,7 +201,7 @@ namespace RabbitMqHttpApiClient.Models.NodeModel
         public bool MemAlarm { get; set; }
 
         [JsonProperty("disk_free_limit")]
-        public int DiskFreeLimit { get; set; }
+        public long DiskFreeLimit { get; set; }
 
         [JsonProperty("disk_free_alarm")]
         public bool DiskFreeAlarm { get; set; }

--- a/RabbitMqHttpApiClient/Models/OverviewModel/Overview.cs
+++ b/RabbitMqHttpApiClient/Models/OverviewModel/Overview.cs
@@ -36,7 +36,7 @@ namespace RabbitMqHttpApiClient.Models.OverviewModel
         public ObjectTotals ObjectTotals { get; set; }
 
         [JsonProperty("statistics_db_event_queue")]
-        public int StatisticsDbEventQueue { get; set; }
+        public long StatisticsDbEventQueue { get; set; }
 
         [JsonProperty("node")]
         public string Node { get; set; }

--- a/RabbitMqHttpApiClient/Models/OverviewModel/QueueTotals.cs
+++ b/RabbitMqHttpApiClient/Models/OverviewModel/QueueTotals.cs
@@ -6,19 +6,19 @@ namespace RabbitMqHttpApiClient.Models.OverviewModel
     public class QueueTotals
     {
         [JsonProperty("messages")]
-        public int Messages { get; set; }
+        public long Messages { get; set; }
 
         [JsonProperty("messages_details")]
         public RateDetails MessagesDetails { get; set; }
 
         [JsonProperty("messages_ready")]
-        public int MessagesReady { get; set; }
+        public long MessagesReady { get; set; }
 
         [JsonProperty("messages_ready_details")]
         public RateDetails MessagesReadyDetails { get; set; }
 
         [JsonProperty("messages_unacknowledged")]
-        public int MessagesUnacknowledged { get; set; }
+        public long MessagesUnacknowledged { get; set; }
 
         [JsonProperty("messages_unacknowledged_details")]
         public RateDetails MessagesUnacknowledgedDetails { get; set; }

--- a/RabbitMqHttpApiClient/Models/QueueModel/BackingQueueStatus.cs
+++ b/RabbitMqHttpApiClient/Models/QueueModel/BackingQueueStatus.cs
@@ -8,28 +8,28 @@ namespace RabbitMqHttpApiClient.Models.QueueModel
         public string Mode { get; set; }
 
         [JsonProperty("q1")]
-        public int Q1 { get; set; }
+        public long Q1 { get; set; }
 
         [JsonProperty("q2")]
-        public int Q2 { get; set; }
+        public long Q2 { get; set; }
 
         [JsonProperty("delta")]
         public object[] Delta { get; set; }
 
         [JsonProperty("q3")]
-        public int Q3 { get; set; }
+        public long Q3 { get; set; }
 
         [JsonProperty("q4")]
-        public int Q4 { get; set; }
+        public long Q4 { get; set; }
 
         [JsonProperty("len")]
-        public int Len { get; set; }
+        public long Len { get; set; }
 
         [JsonProperty("target_ram_count")]
         public string TargetRamCount { get; set; }
 
         [JsonProperty("next_seq_id")]
-        public int NextSeqId { get; set; }
+        public long NextSeqId { get; set; }
 
         [JsonProperty("avg_ingress_rate")]
         public double AvgIngressRate { get; set; }

--- a/RabbitMqHttpApiClient/Models/QueueModel/GetQueueMessagesRequest.cs
+++ b/RabbitMqHttpApiClient/Models/QueueModel/GetQueueMessagesRequest.cs
@@ -2,7 +2,7 @@ namespace RabbitMqHttpApiClient.Models.QueueModel
 {
     public class GetQueueMessagesRequest 
     {
-        public int count { get; set; }
+        public long count { get; set; }
         public bool requeue { get; set; }
         public string encoding { get; set; }
     }

--- a/RabbitMqHttpApiClient/Models/QueueModel/Queue.cs
+++ b/RabbitMqHttpApiClient/Models/QueueModel/Queue.cs
@@ -6,31 +6,31 @@ namespace RabbitMqHttpApiClient.Models.QueueModel
     public class Queue
     {
         [JsonProperty("memory")]
-        public int Memory { get; set; }
+        public long Memory { get; set; }
 
         [JsonProperty("message_stats")]
         public QueueMessageStats MessageStats { get; set; }
 
         [JsonProperty("reductions")]
-        public int Reductions { get; set; }
+        public long Reductions { get; set; }
 
         [JsonProperty("reductions_details")]
         public RateDetails ReductionsDetails { get; set; }
 
         [JsonProperty("messages")]
-        public int Messages { get; set; }
+        public long Messages { get; set; }
 
         [JsonProperty("messages_details")]
         public RateDetails MessagesDetails { get; set; }
 
         [JsonProperty("messages_ready")]
-        public int MessagesReady { get; set; }
+        public long MessagesReady { get; set; }
 
         [JsonProperty("messages_ready_details")]
         public RateDetails MessagesReadyDetails { get; set; }
 
         [JsonProperty("messages_unacknowledged")]
-        public int MessagesUnacknowledged { get; set; }
+        public long MessagesUnacknowledged { get; set; }
 
         [JsonProperty("messages_unacknowledged_details")]
         public RateDetails MessagesUnacknowledgedDetails { get; set; }
@@ -60,40 +60,40 @@ namespace RabbitMqHttpApiClient.Models.QueueModel
         public GarbageCollection GarbageCollection { get; set; }
 
         [JsonProperty("messages_ram")]
-        public int MessagesRam { get; set; }
+        public long MessagesRam { get; set; }
 
         [JsonProperty("messages_ready_ram")]
-        public int MessagesReadyRam { get; set; }
+        public long MessagesReadyRam { get; set; }
 
         [JsonProperty("messages_unacknowledged_ram")]
-        public int MessagesUnacknowledgedRam { get; set; }
+        public long MessagesUnacknowledgedRam { get; set; }
 
         [JsonProperty("messages_persistent")]
-        public int MessagesPersistent { get; set; }
+        public long MessagesPersistent { get; set; }
 
         [JsonProperty("message_bytes")]
-        public int MessageBytes { get; set; }
+        public long MessageBytes { get; set; }
 
         [JsonProperty("message_bytes_ready")]
-        public int MessageBytesReady { get; set; }
+        public long MessageBytesReady { get; set; }
 
         [JsonProperty("message_bytes_unacknowledged")]
-        public int MessageBytesUnacknowledged { get; set; }
+        public long MessageBytesUnacknowledged { get; set; }
 
         [JsonProperty("message_bytes_ram")]
-        public int MessageBytesRam { get; set; }
+        public long MessageBytesRam { get; set; }
 
         [JsonProperty("message_bytes_persistent")]
-        public int MessageBytesPersistent { get; set; }
+        public long MessageBytesPersistent { get; set; }
 
         [JsonProperty("head_message_timestamp")]
         public object HeadMessageTimestamp { get; set; }
 
         [JsonProperty("disk_reads")]
-        public int DiskReads { get; set; }
+        public long DiskReads { get; set; }
 
         [JsonProperty("disk_writes")]
-        public int DiskWrites { get; set; }
+        public long DiskWrites { get; set; }
 
         [JsonProperty("backing_queue_status")]
         public BackingQueueStatus BackingQueueStatus { get; set; }

--- a/RabbitMqHttpApiClient/Models/QueueModel/QueueMessage.cs
+++ b/RabbitMqHttpApiClient/Models/QueueModel/QueueMessage.cs
@@ -6,7 +6,7 @@ namespace RabbitMqHttpApiClient.Models.QueueModel
     public class QueueMessage
     {
         [JsonProperty("payload_bytes")]
-        public int PayloadBytes { get; set; }
+        public long PayloadBytes { get; set; }
 
         [JsonProperty("redelivered")]
         public bool Redelivered { get; set; }
@@ -18,7 +18,7 @@ namespace RabbitMqHttpApiClient.Models.QueueModel
         public string RoutingKey { get; set; }
 
         [JsonProperty("message_count")]
-        public int MessageCount { get; set; }
+        public long MessageCount { get; set; }
 
         [JsonProperty("properties")]
         public Properties Properties { get; set; }

--- a/RabbitMqHttpApiClient/Models/QueueModel/QueueMessageStats.cs
+++ b/RabbitMqHttpApiClient/Models/QueueModel/QueueMessageStats.cs
@@ -5,10 +5,10 @@ namespace RabbitMqHttpApiClient.Models.QueueModel
 {
     public class QueueMessageStats : MessageStats, IDiskInfo
     {
-        public int DiskReads { get; set; }
+        public long DiskReads { get; set; }
         public RateDetails DiskReadsDetails { get; set; }
 
-        public int DiskWrites { get; set; }
+        public long DiskWrites { get; set; }
         public RateDetails DiskWritesDetails { get; set; }
     }
 }


### PR DESCRIPTION
Hi @kuanysh-nabiyev,

I got some JSON serialization exceptions in my tests, because int was not big enough.
`Message	"JSON integer 15243411616 is too large or small for an Int32. Path '[3].reductions', line 1, position 5742."	string`

After looking at https://github.com/michaelklishin/rabbit-hole I changed most int properties to long.