### PR TITLE
Queue.ConsumerUtilisation can be null. Changed type to double?

### DIFF
--- a/RabbitMqHttpApiClient/Models/QueueModel/Queue.cs
+++ b/RabbitMqHttpApiClient/Models/QueueModel/Queue.cs
@@ -39,7 +39,7 @@ namespace RabbitMqHttpApiClient.Models.QueueModel
         public string IdleSince { get; set; }
 
         [JsonProperty("consumer_utilisation")]
-        public double ConsumerUtilisation { get; set; }
+        public double? ConsumerUtilisation { get; set; }
 
         [JsonProperty("policy")]
         public string Policy { get; set; }


### PR DESCRIPTION
Hi @kuanysh-nabiyev,

I have found a JSON deserialization issue with Queueue.ConsumerUtilistation. This PR should help. 